### PR TITLE
Return a 404 when an origin doesn't exist instead of panicking

### DIFF
--- a/components/originsrv/origins/server/server.go
+++ b/components/originsrv/origins/server/server.go
@@ -7,6 +7,9 @@ import (
 	"github.com/chuckleheads/hurtlocker/components/originsrv/origins/request"
 	"github.com/chuckleheads/hurtlocker/components/originsrv/origins/response"
 	_ "github.com/lib/pq"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 type Server struct {
@@ -21,47 +24,62 @@ func (srv *Server) CreateOrigin(ctx context.Context, req *request.CreateOriginRe
 	var id int64
 	// TED: This should be a postgres function, not inline code
 	err := srv.db.
-		QueryRow("INSERT INTO origins(name, default_package_visibility) VALUES($1,$2) RETURNING id", req.Name, req.DefaultPackageVisibility).
+		QueryRow("INSERT INTO origins(name, default_package_visibility) VALUES($1, $2) RETURNING id", req.Name, req.DefaultPackageVisibility).
 		Scan(&id)
+
 	// TED: Handle other errors here like row conflicts
 	if err != nil {
 		panic(err.Error())
 	}
+
 	origin := response.Origin{
 		Id:   id,
 		Name: req.Name,
 		DefaultPackageVisibility: req.DefaultPackageVisibility,
 	}
+
 	originResp := response.OriginResp{
 		Origin: &origin,
 	}
+
 	return &originResp, nil
 }
 
 func (srv *Server) GetOrigin(ctx context.Context, req *request.GetOriginReq) (*response.OriginResp, error) {
 	var origin response.Origin
+
 	err := srv.db.
-		QueryRow("Select * from origins where name = $1", req.Name).
+		QueryRow("SELECT * FROM origins WHERE name = $1", req.Name).
 		Scan(&origin.Id, &origin.Name, &origin.DefaultPackageVisibility)
-	if err != nil {
+
+	if err != nil && err != sql.ErrNoRows {
 		panic(err.Error())
 	}
-	orgresp := response.OriginResp{
-		Origin: &origin,
+
+	if err == nil {
+		resp := response.OriginResp{
+			Origin: &origin,
+		}
+
+		return &resp, nil
+	} else {
+		return nil, grpc.Errorf(codes.NotFound, "%s", req.Name)
 	}
-	return &orgresp, nil
 }
 
 func (srv *Server) UpdateOrigin(ctx context.Context, req *request.UpdateOriginReq) (*response.OriginResp, error) {
 	var origin response.Origin
 	err := srv.db.
-		QueryRow("UPDATE origins set default_package_visibility = $1 where name = $2 RETURNING *", req.DefaultPackageVisibility, req.Name).
+		QueryRow("UPDATE origins SET default_package_visibility = $1 WHERE name = $2 RETURNING *", req.DefaultPackageVisibility, req.Name).
 		Scan(&origin.Id, &origin.Name, &origin.DefaultPackageVisibility)
+
 	if err != nil {
 		panic(err.Error())
 	}
+
 	orgresp := response.OriginResp{
 		Origin: &origin,
 	}
+
 	return &orgresp, nil
 }


### PR DESCRIPTION
This isn't perfect, because the actual response you get back is kinda cryptic, but I haven't figured out how to make it less cryptic yet.

Closes https://github.com/chuckleheads/hurtlocker/issues/1
Signed-off-by: Josh Black <raskchanky@gmail.com>