### PR TITLE
Add envoy proxy plan

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -47,6 +47,7 @@ start-hurtlocker() {
   start-originsrv
   start-agent
   start-sessionsrv
+  start-router
 }
 
 stop-hurtlocker() {
@@ -55,6 +56,7 @@ stop-hurtlocker() {
   stop-originsrv
   stop-agent
   stop-sessionsrv
+  stop-router
 }
 
 start-rabbitmq() {
@@ -95,6 +97,14 @@ start-agent() {
 
 stop-agent() {
     hab svc unload chuckleheads/agent
+}
+
+start-router() {
+  hab svc load chuckleheads/router --bind originsrv:originsrv.default --bind sessionsrv:sessionsrv.default
+}
+
+stop-router() {
+  hab svc unload chuckleheads/router
 }
 
 _build-component() {

--- a/components/originsrv/cmd/root.go
+++ b/components/originsrv/cmd/root.go
@@ -40,6 +40,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is /hab/svc/originsrv/config/config.toml)")
+	viper.SetDefault("port", 7001)
+	viper.SetDefault("http_port", 7002)
 	viper.SetDefault("datastore.host", "localhost")
 	viper.SetDefault("datastore.port", 26257)
 	viper.SetDefault("datastore.database", "originsrv")

--- a/components/originsrv/config/config.go
+++ b/components/originsrv/config/config.go
@@ -1,5 +1,7 @@
 package config
 
 type Config struct {
+	Port      int
+	HttpPort  int
 	Datastore DBConfig
 }

--- a/components/originsrv/habitat/default.toml
+++ b/components/originsrv/habitat/default.toml
@@ -1,2 +1,5 @@
+port = 7001
+http_port = 7002
+
 [datastore]
 database = "originsrv"

--- a/components/originsrv/habitat/plan.sh
+++ b/components/originsrv/habitat/plan.sh
@@ -12,3 +12,8 @@ pkg_deps=(core/cockroach)
 pkg_binds=(
   [datastore]="port"
 )
+pkg_exports=(
+  [port]=port
+  [http_port]=http_port
+)
+pkg_exposes=(port http_port)

--- a/components/router/config/grpc-bridge.yaml
+++ b/components/router/config/grpc-bridge.yaml
@@ -1,0 +1,73 @@
+admin:
+  access_log_path: "{{pkg.svc_var_path}}/admin_access.log"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9211
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              {{~#if bind.originsrv}}
+              - match:
+                  prefix: "/originsrv"
+                  headers:
+                  - name: content-type
+                    value: application/grpc
+                route:
+                  cluster: originsrv
+              {{~/if}}
+              {{~#if bind.sessionsrv}}
+              - match:
+                  prefix: "/sessionsrv"
+                  headers:
+                  - name: content-type
+                    value: application/grpc
+                route:
+                  cluster: sessionsrv
+              {{~/if}}
+          http_filters:
+          - name: envoy.router
+            config: {}
+  clusters:
+  {{~#if bind.originsrv}}
+  - name: originsrv
+    connect_timeout: 0.250s
+    type: static
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    {{~#eachAlive bind.originsrv.members as |member|}}
+    - socket_address:
+        address: {{member.sys.ip}}
+        port_value: {{member.cfg.port}}
+    {{~/eachAlive}}
+  {{~/if}}
+  {{~#if bind.sessionsrv}}
+  - name: sessionsrv
+    connect_timeout: 0.250s
+    type: static
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    {{~#eachAlive bind.sessionsrv.members as |member|}}
+    - socket_address:
+        address: {{member.sys.ip}}
+        port_value: {{member.cfg.port}}
+    {{~/eachAlive}}
+  {{~/if}}

--- a/components/router/hooks/run
+++ b/components/router/hooks/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec 2>&1
+
+exec envoy -c "{{pkg.svc_config_path}}/grpc-bridge.yaml"

--- a/components/router/plan.sh
+++ b/components/router/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=router
+pkg_origin=chuckleheads
+pkg_version=0.0.1
+pkg_description="envoy proxy for builder chuckleheads"
+pkg_upstream_url="https://github.com/chuckleheads/hurtlocker"
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_deps=(core/envoy)
+pkg_svc_user="root"
+pkg_svc_group="root"
+# Since Habitat doesn't have a way to declare a bind *for* another service
+# We have to list all permutations here 
+pkg_binds_optional=(
+  [originsrv]="port"
+  [sessionsrv]="port"
+)
+# pkg_exports=(
+#   [port]=port
+# )
+# pkg_exposes=(port)
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  return 0
+}

--- a/components/sessionsrv/cmd/root.go
+++ b/components/sessionsrv/cmd/root.go
@@ -35,6 +35,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is /hab/svc/sessionsrv/config/config.toml)")
+	viper.SetDefault("port", 8001)
+	viper.SetDefault("http_port", 8002)
 	viper.SetDefault("datastore.host", "localhost")
 	viper.SetDefault("datastore.port", 26257)
 	viper.SetDefault("datastore.database", "sessionsrv")

--- a/components/sessionsrv/config/config.go
+++ b/components/sessionsrv/config/config.go
@@ -1,5 +1,7 @@
 package config
 
 type Config struct {
+	Port      int
+	HttpPort  int
 	Datastore DBConfig
 }

--- a/components/sessionsrv/habitat/default.toml
+++ b/components/sessionsrv/habitat/default.toml
@@ -1,2 +1,5 @@
+port = 8001
+http_port = 8002
+
 [datastore]
 database = "sessionsrv"

--- a/components/sessionsrv/habitat/plan.sh
+++ b/components/sessionsrv/habitat/plan.sh
@@ -12,3 +12,8 @@ pkg_deps=(core/cockroach)
 pkg_binds=(
   [datastore]="port"
 )
+pkg_exports=(
+  [port]=port
+  [http_port]=http_port
+)
+pkg_exposes=(port http_port)


### PR DESCRIPTION
Since we don't have reverse binds this might look a little strange but the router needs to bind to it's child service, not the other way around.

Added dynamic ports to the config.

Signed-off-by: Elliott Davis <elliott@excellent.io>