### PR TITLE
Wire build task runner into agent

### DIFF
--- a/components/agent/dispatcher/build.go
+++ b/components/agent/dispatcher/build.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/chuckleheads/hurtlocker/components/agent/proto/build"
+	"github.com/go-cmd/cmd"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -12,5 +13,15 @@ func Build(buildReq []byte) {
 	if err := proto.Unmarshal(buildReq, build); err != nil {
 		log.Fatalln("Failed to parse Build:", err)
 	}
-	log.Printf("Received a message: %s", build)
+	runBuild(build)
+}
+
+func runBuild(payload *build.Build) {
+	cmdOptions := cmd.Options{
+		Buffered:  false,
+		Streaming: false,
+	}
+	tasker := cmd.NewCmdOptions(cmdOptions, "hab", "pkg", "exec", "chuckleheads/tasker", "tasker", "build", payload.GetPackagePath())
+	// Fire and forget - we don't care about the status because we are just dispatching a task runner
+	tasker.Start()
 }


### PR DESCRIPTION
Actually attempt to run a build when an action is pushed onto
the work queue

Signed-off-by: Elliott Davis <elliott@excellent.io>